### PR TITLE
Environment variables should be set at system level

### DIFF
--- a/Components/talksapi/cloudformation.template
+++ b/Components/talksapi/cloudformation.template
@@ -163,11 +163,11 @@
                                         "", 
                                         [
                                             "setx SPEAKR_DB_SERVER ", {"Fn::ImportValue" : "DbSpeakrRocksServer"},
-                                            "|",
+                                            " /M |",
                                             "setx SPEAKR_DB_NAME ", {"Fn::ImportValue" : "DbSpeakrRocksName"},
-                                            "|",
+                                            " /M |",
                                             "setx SPEAKR_DB_USER ", {"Fn::ImportValue" : "DbSpeakrRocksUser"},
-                                            "|",
+                                            " /M |",
                                             "setx SPEAKR_DB_PASSWORD ", {"Fn::ImportValue" : "DbSpeakrRocksPassword"}
                                         ]
                                     ]

--- a/Components/webapp/cloudformation.template
+++ b/Components/webapp/cloudformation.template
@@ -163,11 +163,11 @@
                                         "", 
                                         [
                                             "setx SPEAKR_DB_SERVER ", {"Fn::ImportValue" : "DbSpeakrRocksServer"},
-                                            "|",
+                                            " /M |",
                                             "setx SPEAKR_DB_NAME ", {"Fn::ImportValue" : "DbSpeakrRocksName"},
-                                            "|",
+                                            " /M |",
                                             "setx SPEAKR_DB_USER ", {"Fn::ImportValue" : "DbSpeakrRocksUser"},
-                                            "|",
+                                            " /M |",
                                             "setx SPEAKR_DB_PASSWORD ", {"Fn::ImportValue" : "DbSpeakrRocksPassword"}
                                         ]
                                     ]

--- a/EnvironmentSetup/database_setup/cloudformation.template
+++ b/EnvironmentSetup/database_setup/cloudformation.template
@@ -1,7 +1,7 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
 
-    "Description" : "Creates MySql Database in RDS",
+    "Description" : "Creates Stack for speakrdb RDS Cluster",
 
     "Parameters" : {
         "MasterUsername": {

--- a/EnvironmentSetup/database_setup/rds_setup.ps1
+++ b/EnvironmentSetup/database_setup/rds_setup.ps1
@@ -5,7 +5,7 @@ Param(
 
     [Parameter()]
     [string]
-    $route53DnsName = "db.speakr.rocks."
+    $route53DnsName = "db.speakr.rocks"
 )
 
 Import-Module AWSPowerShell


### PR DESCRIPTION
- the /M tag sets variable at system level
- Also, the Route53 DNS name needs the . but aws is clever enough to add it itself. However, we cannot use the . in the config strings. so we remove it here, and bump up the dns as a cross CFN variable to be reused by configs.