### PR TITLE
Update AMI, don't store keypair.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ bh_unicode_properties.cache
 # Sublime-github package stores a github token in this file
 # https://packagecontrol.io/packages/sublime-github
 GitHub.sublime-settings
+keypair.txt

--- a/Components/talksapi/EnvironmentSetup.ps1
+++ b/Components/talksapi/EnvironmentSetup.ps1
@@ -37,7 +37,7 @@ function _LaunchCloudFormationStack([string]$instanceType, [string]$keyPair, [bo
     $templatePath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "./cloudformation.template"))
     $templateBody = [System.IO.File]::ReadAllText($templatePath)
 
-    $imageId = "ami-55084526"
+    $imageId = "ami-dd9eb6ae"
 
     $param1 = New-Object  -TypeName Amazon.CloudFormation.Model.Parameter
     $param1.ParameterKey = "ImageId"

--- a/Components/webapp/EnvironmentSetup.ps1
+++ b/Components/webapp/EnvironmentSetup.ps1
@@ -37,7 +37,7 @@ function _LaunchCloudFormationStack([string]$instanceType, [string]$keyPair, [bo
     $templatePath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "./cloudformation.template"))
     $templateBody = [System.IO.File]::ReadAllText($templatePath)
 
-    $imageId = "ami-55084526"
+    $imageId = "ami-dd9eb6ae"
 
     $param1 = New-Object  -TypeName Amazon.CloudFormation.Model.Parameter
     $param1.ParameterKey = "ImageId"


### PR DESCRIPTION
Keypair.txt is generated and copied from AWS by the scripts. Useful to RDP into instances, but shouldn't be in source control because reasons